### PR TITLE
feat(annotations): Clean up annotation options layout.

### DIFF
--- a/src/os/ui/color/colorpicker.js
+++ b/src/os/ui/color/colorpicker.js
@@ -97,18 +97,12 @@ os.ui.color.ColorPickerCtrl = function($scope, $element, $compile) {
    */
   this['showPopup'] = false;
 
-  var color = /** @type {string} */ (this.scope['color']);
-
-  // default color is undefine if one was not set, it will use default theme setting
-  if (!color) {
-    color = undefined;
-  }
-
-  if ((color !== undefined) && (color.indexOf('#') !== 0)) {
+  // the control's color value should be undefined when the picker is set to the default color
+  var color = /** @type {string} */ (this.scope['color']) || undefined;
+  if (color && color.indexOf('#') !== 0) {
     // if color was set to something other than a hex string (rgb() or rgba()), then fix it
     color = (color.indexOf('a(') > -1 ? goog.color.alpha.parse(color) : goog.color.parse(color)).hex.substring(0, 7);
   }
-
 
   this.scope['color'] = color;
 

--- a/views/annotation/annotationoptions.html
+++ b/views/annotation/annotationoptions.html
@@ -6,18 +6,20 @@
   <div class="card-body collapse"
       data-parent="#featureControls{{ctrl.uid}}" ng-attr-id="featureAnnotation{{ctrl.uid}}">
     <div class="form-row">
-      <div class="custom-control custom-checkbox d-inline-block"
-          title="Show an interactive map annotation for this feature">
-        <input type="checkbox" class="custom-control-input" name="showAnnotation"
-            ng-attr-id="showAnnotation{{ctrl.uid}}"
-            ng-change="ctrl.updateAnnotation()"
-            ng-model="ctrl.annotationOptions.show" />
-        <label class="custom-control-label" ng-attr-for="showAnnotation{{ctrl.uid}}">
-          Show Annotation
-        </label>
+      <div class="col">
+        <div class="custom-control custom-checkbox d-inline-block"
+            title="Show an interactive map annotation for this feature">
+          <input type="checkbox" class="custom-control-input" name="showAnnotation"
+              ng-attr-id="showAnnotation{{ctrl.uid}}"
+              ng-change="ctrl.updateAnnotation()"
+              ng-model="ctrl.annotationOptions.show" />
+          <label class="custom-control-label" ng-attr-for="showAnnotation{{ctrl.uid}}">
+            Show Annotation
+          </label>
+        </div>
       </div>
     </div>
-    <div class="form-row">
+    <div class="form-row align-items-center">
       <div class="col">
         <div class="custom-control custom-checkbox d-inline-block"
             title="Show the Name field as the annotation header">
@@ -38,13 +40,13 @@
                 show-reset="true"
                 title="Sets the background color for header"
                 disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName"></colorpicker>
-            <label ng-attr-for="headerColor{{ctrl.uid}}">
+            <label class="col-form-label" ng-attr-for="headerColor{{ctrl.uid}}">
               Header Background
             </label>
           </div>
         </div>
       </div>
-      <div class="form-row">
+      <div class="form-row align-items-center">
         <div class="col">
           <div class="custom-control custom-checkbox d-inline-block"
               title="Show the Description field in the annotation">
@@ -66,28 +68,30 @@
                   show-reset="true"
                   title="Sets the background color for body"
                   disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription"></colorpicker>
-              <label ng-attr-for="bodyColor{{ctrl.uid}}">Description Background</label>
+              <label class="col-form-label" ng-attr-for="bodyColor{{ctrl.uid}}">Description Background</label>
             </div>
         </div>
       </div>
       <div class="form-group">
-        <div class="col form-label">Tail Style</div>
-        <div class="custom-control custom-checkbox d-inline-block">
-          <input ng-checked="true" type="radio" ng-attr-id="showAnnotationDefaultTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail"
-            ng-change="ctrl.updateAnnotation()" value="default" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show"
-          />
-          <label class="form-check-label" ng-attr-for="showAnnotationDefaultTail{{ctrl.uid}}" ng-disabled="disabled">Default</label>
-        </div>
-        <div class="custom-control custom-checkbox d-inline-block">
-          <input type="radio" ng-attr-id="showAnnotationLineTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" value="line"
-            ng-change="ctrl.updateAnnotation()" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show"
-          />
-          <label class="form-check-label" ng-attr-for="showAnnotationLineTail{{ctrl.uid}}" ng-disabled="disabled">Line</label>
-        </div>
-        <div class="custom-control custom-checkbox d-inline-block">
-          <input type="radio" ng-attr-id="showAnnotationNoTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" ng-change="ctrl.updateAnnotation()"
-            value="none" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show" />
-          <label class="form-check-label" ng-attr-for="showAnnotationNoTail{{ctrl.uid}}" ng-disabled="disabled">None</label>
+        <div class="col">
+          <label class="col-form-label mr-2">Tail Style</label>
+          <div class="custom-control custom-checkbox d-inline-block">
+            <input ng-checked="true" type="radio" ng-attr-id="showAnnotationDefaultTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail"
+              ng-change="ctrl.updateAnnotation()" value="default" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show"
+            />
+            <label class="form-check-label" ng-attr-for="showAnnotationDefaultTail{{ctrl.uid}}" ng-disabled="disabled">Default</label>
+          </div>
+          <div class="custom-control custom-checkbox d-inline-block">
+            <input type="radio" ng-attr-id="showAnnotationLineTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" value="line"
+              ng-change="ctrl.updateAnnotation()" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show"
+            />
+            <label class="form-check-label" ng-attr-for="showAnnotationLineTail{{ctrl.uid}}" ng-disabled="disabled">Line</label>
+          </div>
+          <div class="custom-control custom-checkbox d-inline-block">
+            <input type="radio" ng-attr-id="showAnnotationNoTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" ng-change="ctrl.updateAnnotation()"
+              value="none" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show" />
+            <label class="form-check-label" ng-attr-for="showAnnotationNoTail{{ctrl.uid}}" ng-disabled="disabled">None</label>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Condensed color picker default code and adjusted the annotation options layout after merge with tail style controls.

Before:
<img width="691" alt="Screen Shot 2019-06-04 at 6 55 34 AM" src="https://user-images.githubusercontent.com/5685437/58880729-d7c87b00-8695-11e9-99cf-936c73f7cdda.png">

After:
<img width="690" alt="Screen Shot 2019-06-04 at 6 55 01 AM" src="https://user-images.githubusercontent.com/5685437/58880715-cd0de600-8695-11e9-91b2-cda00c7d7409.png">